### PR TITLE
打包H2数据库

### DIFF
--- a/lealone-opscenter/opscenter-dist/assembly.xml
+++ b/lealone-opscenter/opscenter-dist/assembly.xml
@@ -58,6 +58,11 @@
             <source>opscenter-dist/target/lealone-opscenter-${project.version}.jar</source>
             <outputDirectory>lib</outputDirectory>
         </file>
+		
+		<file>
+            <source>opscenter-dal/h2/h2-2.0.201.jar</source>
+            <outputDirectory>lib</outputDirectory>
+        </file>
     </files>
 
     <moduleSets>


### PR DESCRIPTION
H2数据库的jar包scope为`system`，编译打包后不会进入 `lealone-opscenter-1.0.0.jar`包里，启动时报错找不到类 `org/h2/util/SortedProperties` 。

这个jar报引入到定义的classpath中，可以正常启动了

```
INFO  17:45:32.491 Lealone version: 5.0.0-SNAPSHOT
INFO  17:45:32.496 Loading config from file:/D:/openSources/lealonePrj/Lealone-Examples/lealone-opscenter/target/lealone-opscenter-1.0.0/conf/lealone.yaml
INFO  17:45:32.544 Base dir: ../data
INFO  17:45:32.573 Init storage engines: 3 ms
INFO  17:45:32.618 Init transaction engines: 44 ms
INFO  17:45:32.620 Init sql engines: 1 ms
WARN  17:45:32.637 Failed to init protocol server engine: HTTP
java.lang.NoClassDefFoundError: org/h2/util/SortedProperties
        at org.lealone.opscenter.web.OpsCenterRouterFactory.<init>(OpsCenterRouterFactory.java:48) ~[lealone-opscenter-1.0.0.jar:na]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:1.8.0_181]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[na:1.8.0_181]
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:1.8.0_181]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[na:1.8.0_181]
        at java.lang.Class.newInstance(Class.java:442) ~[na:1.8.0_181]
        at org.lealone.server.http.HttpServer.init(HttpServer.java:129) ~[lealone-opscenter-1.0.0.jar:na]
        at org.lealone.server.http.HttpServerEngine.init(HttpServerEngine.java:41) ~[lealone-opscenter-1.0.0.jar:na]
        at org.lealone.main.Lealone.initPluggableEngine(Lealone.java:277) [lealone-opscenter-1.0.0.jar:na]
        at org.lealone.main.Lealone.registerAndInitEngines(Lealone.java:248) [lealone-opscenter-1.0.0.jar:na]
        at org.lealone.main.Lealone.initProtocolServerEngines(Lealone.java:204) [lealone-opscenter-1.0.0.jar:na]
        at org.lealone.main.Lealone.initPluggableEngines(Lealone.java:155) [lealone-opscenter-1.0.0.jar:na]
        at org.lealone.main.Lealone.init(Lealone.java:124) [lealone-opscenter-1.0.0.jar:na]
        at org.lealone.main.Lealone.main(Lealone.java:74) [lealone-opscenter-1.0.0.jar:na]
        at org.lealone.main.Lealone.main(Lealone.java:56) [lealone-opscenter-1.0.0.jar:na]
Caused by: java.lang.ClassNotFoundException: org.h2.util.SortedProperties
        at java.net.URLClassLoader.findClass(URLClassLoader.java:381) ~[na:1.8.0_181]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[na:1.8.0_181]
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349) ~[na:1.8.0_181]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[na:1.8.0_181]
        ... 15 common frames omitted
INFO  17:45:32.639 Init protocol server engines: 19 ms
INFO  17:45:32.715 Init lealone database: 76 ms
INFO  17:45:32.717 Starting nio net server
INFO  17:45:32.874 TcpServer started, host: 127.0.0.1, port: 9210
ERROR 17:45:33.009 Fatal error: unable to start lealone. See log for stacktrace.
java.lang.NullPointerException: null
        at org.lealone.server.http.HttpRouterFactory.setStaticHandler(HttpRouterFactory.java:139) ~[lealone-opscenter-1.0.0.jar:na]
        at org.lealone.server.http.HttpRouterFactory.createRouter(HttpRouterFactory.java:49) ~[lealone-opscenter-1.0.0.jar:na]
        at org.lealone.server.http.HttpServer.startVertxHttpServer(HttpServer.java:198) ~[lealone-opscenter-1.0.0.jar:na]
        at org.lealone.server.http.HttpServer.start(HttpServer.java:164) ~[lealone-opscenter-1.0.0.jar:na]
        at org.lealone.main.Lealone.startProtocolServer(Lealone.java:302) [lealone-opscenter-1.0.0.jar:na]
        at org.lealone.main.Lealone.startProtocolServers(Lealone.java:293) [lealone-opscenter-1.0.0.jar:na]
        at org.lealone.main.Lealone.start(Lealone.java:281) [lealone-opscenter-1.0.0.jar:na]
        at org.lealone.main.Lealone.main(Lealone.java:82) [lealone-opscenter-1.0.0.jar:na]
        at org.lealone.main.Lealone.main(Lealone.java:56) [lealone-opscenter-1.0.0.jar:na]
INFO  17:45:33.047 Stopping nio net server
INFO  17:45:33.048 TcpServer stopped
```

